### PR TITLE
fix: send X-Client-Session-Id on correct headers object

### DIFF
--- a/src/taskpane/utils/api.ts
+++ b/src/taskpane/utils/api.ts
@@ -193,7 +193,7 @@ export const useApiMutation = <InputType, ResponseType>({
                 'Content-Type': 'application/json',
                 'X-Client-Type': 'Excel'
             }
-            if(!!sessionId) headers['X-Client-Session-Id'] = sessionId;
+            if(!!sessionId) requestHeaders['X-Client-Session-Id'] = sessionId;
 
             try {
                 response = await fetch(`${apiUrl}/${mutationUrl}`, {


### PR DESCRIPTION
## Summary
- The `X-Client-Session-Id` header was being set on the wrong object (`headers` from `useHeaders()`) instead of `requestHeaders` (the object actually passed to `fetch`), causing mutation requests to fail with `MissingHeader` error.

## Test plan
- [ ] Verify mutation requests (e.g. creating/updating products) no longer return the `MissingHeader` error
- [ ] Confirm `X-Client-Session-Id` is present in outgoing request headers via browser dev tools