### PR TITLE
fix: send X-Client-Session-Id on the correct headers object

### DIFF
--- a/src/taskpane/utils/api.ts
+++ b/src/taskpane/utils/api.ts
@@ -193,7 +193,7 @@ export const useApiMutation = <InputType, ResponseType>({
                 'Content-Type': 'application/json',
                 'X-Client-Type': 'Excel'
             }
-            if(!!sessionId) headers['X-Client-Session-Id'] = sessionId;
+            if(!!sessionId) requestHeaders['X-Client-Session-Id'] = sessionId;
 
             try {
                 response = await fetch(`${apiUrl}/${mutationUrl}`, {


### PR DESCRIPTION
The session ID was being set on `headers` (from useHeaders()) instead of `requestHeaders` (the object actually passed to fetch), so it never reached the server.