### PR TITLE
chore: add CLAUDE.md, .superset/setup.sh, and TASK.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dist
 
 .env**
 !.env.example
+
+# Per-worktree scratch file
+TASK.md

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Superset worktree setup script for QonicExcel
+set -euo pipefail
+
+BRANCH_NAME="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+
+echo "Setting up QonicExcel worktree for branch: $BRANCH_NAME"
+
+# Copy env files from the root repo if available
+if [ -n "${SUPERSET_ROOT_PATH:-}" ]; then
+  for envfile in .env .env.develop .env.rc; do
+    if [ -f "$SUPERSET_ROOT_PATH/$envfile" ]; then
+      cp "$SUPERSET_ROOT_PATH/$envfile" "./$envfile"
+      echo "Copied $envfile from root"
+    fi
+  done
+fi
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+echo ""
+echo "Setup complete for branch: $BRANCH_NAME"
+echo "  - Dev server:  npm run dev-server   (https://localhost:3000)"
+echo "  - Start:       npm start            (opens Excel with add-in)"
+echo "  - Validate:    npm run validate     (check manifest.xml)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> Cross-repo system map lives in `~/.claude/CLAUDE.md` (user-level, not committed).
+
+## Overview
+
+Qonic Excel Add-In — an Office Add-in that lets users query model data and push modifications back to Qonic directly from within Microsoft Excel. Built with React and the Office.js API.
+
+## Tech Stack
+
+- **React** + **TypeScript** — UI components
+- **Webpack** — bundler (Office Add-in template)
+- **Fluent UI** (`@fluentui/react-components`, `@fluentui/react-icons`) — Microsoft design system
+- **Headless UI** — additional component primitives
+- **TanStack React Query 5** — server state management
+- **Auth0** (`@auth0/auth0-spa-js`) — OAuth PKCE authentication
+- **Axios** — HTTP client
+- **Tailwind CSS** — utility-first styling
+- **Office.js** — Excel API integration
+- **Node.js** — development server
+
+## Commands
+
+```bash
+npm install                # Install dependencies
+npm run dev-server         # Dev server on https://localhost:3000
+npm run server             # Production-mode dev server
+npm run build              # Production build
+npm run build:dev          # Development build
+npm run lint               # Lint check
+npm run lint:fix           # Auto-fix lint issues
+npm start                  # Start add-in in Excel (desktop)
+npm run start:web          # Start add-in in Excel Online
+npm run validate           # Validate manifest.xml
+```
+
+## Project Structure
+
+```
+src/
+├── taskpane/          # Main task pane UI
+│   ├── components/    # React components
+│   ├── excel/         # Excel-specific utilities (cell reads/writes)
+│   └── utils/         # General utilities
+├── commands/          # Excel ribbon command handlers
+└── login/             # Login page/flow
+assets/                # Static assets (images, icons)
+manifest.xml           # Office Add-in manifest (defines capabilities, URLs)
+webpack.config.js      # Webpack configuration
+```
+
+## Key Conventions
+
+- The add-in uses OAuth PKCE flow via Auth0 — credentials are configured via `.env` files
+- `manifest.xml` defines the add-in's capabilities and must be valid — run `npm run validate` to check
+- The dev server runs on HTTPS (required by Office Add-ins) at `https://localhost:3000`
+- Environment variables: `QONIC_CLIENT_ID`, `QONIC_CLIENT_SECRET` (from `.env`)
+- Multiple env configs: `.env` (default), `.env.develop`, `.env.rc`, `.env.example`
+
+## How This Repo Interfaces With Others
+
+- **Consumes**: Qonic Public API for model data queries and modifications
+- **Authentication**: Auth0 (same domain as dashboard-frontend, different client credentials)
+- **Public repo**: Hosted at `github.com/QonicOpen/QonicExcel` (not on GitHub Enterprise)


### PR DESCRIPTION
Add Claude Code documentation and worktree setup:

- **CLAUDE.md**: Project-specific guidance for Claude Code (tech stack, commands, conventions, cross-repo interfaces)
- **.superset/setup.sh**: Worktree setup script (dependency install, env file copy)
- **.gitignore**: Add TASK.md entry for per-worktree scratch files

Cross-repo system map lives in `~/.claude/CLAUDE.md` (user-level, not committed).