### PR TITLE
feat: public client support in OAuth token exchange

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 QONIC_CLIENT_ID=
+# Leave blank for public clients (no client secret required)
 QONIC_CLIENT_SECRET=

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1,6 +1,7 @@
 const apiUrl = process.env.QONIC_API_URL
 const QONIC_CLIENT_ID = process.env.QONIC_CLIENT_ID!;
-const QONIC_CLIENT_SECRET = process.env.QONIC_CLIENT_SECRET!;
+// Optional: leave blank for public clients registered without a client secret
+const QONIC_CLIENT_SECRET = process.env.QONIC_CLIENT_SECRET || "";
 const QONIC_SCOPES = "projects:read models:read models:write";
 
 const REDIRECT_URI = `${window.location.origin}/login.html`
@@ -109,22 +110,16 @@ async function handleCallback(): Promise<void> {
         return;
     }
 
-    console.log({
-        code,
-        redirect_uri: REDIRECT_URI,
-        code_verifier: codeVerifier,
-        grant_type: "authorization_code",
-        client_id: QONIC_CLIENT_ID,
-        client_secret: QONIC_CLIENT_SECRET,
-    })
-
     const form = new URLSearchParams();
     form.append("code", code);
     form.append("redirect_uri", REDIRECT_URI);
     form.append("code_verifier", codeVerifier);
     form.append("grant_type", "authorization_code");
     form.append("client_id", QONIC_CLIENT_ID);
-    form.append("client_secret", QONIC_CLIENT_SECRET); // ⚠️ see note below
+    // Public clients have no secret; omit when not configured.
+    if (QONIC_CLIENT_SECRET) {
+        form.append("client_secret", QONIC_CLIENT_SECRET);
+    }
 
     const resp = await fetch(`${apiUrl}/auth/token`, {
         method: "POST",


### PR DESCRIPTION
## Summary

Updates to align with Qonic PublicAPI security hardening (iQonic/Qonic#20318):

- **Public client support** (`src/login/login.ts`): `client_secret` is now omitted from the token exchange form when `QONIC_CLIENT_SECRET` is not set. The PublicAPI now rejects a secret for public clients (`IsPublicClient: true`) with a `400`; confidential clients are unaffected.
- `QONIC_CLIENT_SECRET` is typed as `string` with an empty-string fallback instead of a non-null assertion (`!`), so an unconfigured public client works without touching `.env`.
- Removed the debug `console.log` block that leaked credential values.
- **`.env.example`**: added note that `QONIC_CLIENT_SECRET` is optional for public clients.

## Test plan

- [ ] Confidential client (secret set): login flow still works end-to-end in Excel
- [ ] Public client (secret empty in `.env`): login flow completes without sending `client_secret`