### PR TITLE
feat[auth]: use default public API Excel client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,1 @@
 QONIC_CLIENT_ID=
-# Leave blank for public clients (no client secret required)
-QONIC_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ To install and set up the Qonic Excel add-in, follow these steps:
 ### 1. Prerequisites
 
 -	[Node.js](https://nodejs.org/)
--	A Qonic Application in the [Developer Portal](https://developer.qonic.com)
+-	A Qonic account
 
-You’ll need:
-- Client ID and Client Secret
-- Whitelisted Redirect URI: https://localhost:3000/login.html
+By default, this add-in uses Qonic's pre-registered public OAuth client. To test your own app registration, set `QONIC_CLIENT_ID` to your application's client id and whitelist `https://localhost:3000/login.html`.
 
 ### 2.  Copy the environment template
 ```bash
@@ -31,9 +29,8 @@ cp .env.example .env
 
 ### 3. Configure .env
 ```bash
-# From your Developer Portal application
+# Optional: override Qonic's default Excel client
 QONIC_CLIENT_ID=YOUR_CLIENT_ID
-QONIC_CLIENT_SECRET=YOUR_CLIENT_SECRET
 ```
 
 ### 3. Install Dependencies:

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1,11 +1,11 @@
 const apiUrl = process.env.QONIC_API_URL
-const QONIC_CLIENT_ID = process.env.QONIC_CLIENT_ID!;
-// Optional: leave blank for public clients registered without a client secret
-const QONIC_CLIENT_SECRET = process.env.QONIC_CLIENT_SECRET || "";
+const QONIC_CLIENT_ID = process.env.QONIC_CLIENT_ID ?? "";
 const QONIC_SCOPES = "projects:read models:read models:write";
+const APPLICATION_KEY = "qonic_excel";
 
 const REDIRECT_URI = `${window.location.origin}/login.html`
 const PKCE_STORAGE_KEY = process.env.API_ENV ? process.env.API_ENV + "_qonic_pkce" : "qonic_pkce";
+let clientIdPromise: Promise<string> | undefined;
 
 function randomString(length: number, chars: string): string {
     let result = "";
@@ -42,6 +42,29 @@ async function makeCodeChallenge(verifier: string): Promise<string> {
     return base64UrlEncode(digest);
 }
 
+async function getClientId(): Promise<string> {
+    if (QONIC_CLIENT_ID) {
+        return QONIC_CLIENT_ID;
+    }
+
+    clientIdPromise ??= fetch(`${apiUrl}/public-api-applications/config`)
+        .then(async (resp) => {
+            if (!resp.ok) {
+                throw new Error(`public_app_config_failed:${resp.status}`);
+            }
+
+            const applications = await resp.json();
+            const clientId = applications?.[APPLICATION_KEY];
+            if (!clientId) {
+                throw new Error(`missing_public_app_client_id:${APPLICATION_KEY}`);
+            }
+
+            return clientId;
+        });
+
+    return clientIdPromise;
+}
+
 function makeState(length = 24): string {
     const alphabet =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -49,6 +72,7 @@ function makeState(length = 24): string {
 }
 
 async function startAuthorize(): Promise<void> {
+    const clientId = await getClientId();
     const codeVerifier = makeCodeVerifier(64);
     const codeChallenge = await makeCodeChallenge(codeVerifier);
     const state = makeState(24);
@@ -57,7 +81,7 @@ async function startAuthorize(): Promise<void> {
     sessionStorage.setItem(`${PKCE_STORAGE_KEY}_state`, state);
 
     const params = new URLSearchParams({
-        client_id: QONIC_CLIENT_ID,
+        client_id: clientId,
         redirect_uri: REDIRECT_URI,
         scope: QONIC_SCOPES,
         state,
@@ -71,6 +95,7 @@ async function startAuthorize(): Promise<void> {
 }
 
 async function handleCallback(): Promise<void> {
+    const clientId = await getClientId();
     const qs = new URLSearchParams(window.location.search);
     const code = qs.get("code");
     const returnedState = qs.get("state") ?? "";
@@ -110,16 +135,20 @@ async function handleCallback(): Promise<void> {
         return;
     }
 
+    console.log({
+        code,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: codeVerifier,
+        grant_type: "authorization_code",
+        client_id: clientId,
+    })
+
     const form = new URLSearchParams();
     form.append("code", code);
     form.append("redirect_uri", REDIRECT_URI);
     form.append("code_verifier", codeVerifier);
     form.append("grant_type", "authorization_code");
-    form.append("client_id", QONIC_CLIENT_ID);
-    // Public clients have no secret; omit when not configured.
-    if (QONIC_CLIENT_SECRET) {
-        form.append("client_secret", QONIC_CLIENT_SECRET);
-    }
+    form.append("client_id", clientId);
 
     const resp = await fetch(`${apiUrl}/auth/token`, {
         method: "POST",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,6 @@ module.exports = async (env, options) => {
   envKeys["process.env.QONIC_API_URL"] = JSON.stringify(envConfig.QONIC_API_URL ?? "https://api.qonic.com/v1");
   envKeys["process.env.API_ENV"] = JSON.stringify(envConfig.API_ENV ?? "release");
   envKeys["process.env.QONIC_CLIENT_ID"] = JSON.stringify(envConfig.QONIC_CLIENT_ID ?? "");
-  envKeys["process.env.QONIC_CLIENT_SECRET"] = JSON.stringify(envConfig.QONIC_CLIENT_SECRET ?? "");
 
   const config = {
     devtool: "source-map",


### PR DESCRIPTION
## Summary
- use Qonic's pre-registered `qonic_excel` public OAuth client by default
- read it from the public discovery response as a plain provisioning-key to client-id map
- keep `QONIC_CLIENT_ID` as an override for users testing their own Developer Portal app
- remove client secret configuration because the add-in uses PKCE as a public client

## Verification
- git diff --check
- npx tsc --noEmit --skipLibCheck --types office-js,node --lib dom,es2020 src/login/login.ts
- rg -n "QONIC_CLIENT_SECRET|client_secret" . --glob "!**/.git/**" --glob "!**/node_modules/**" --glob "!dist/**" || true

## Known Build Blocker
- `npm run build` still fails in unrelated taskpane component typings: missing `@react-types/button`, plus existing `Button` prop type errors for `isDisabled`/`onPress` in taskpane components. The changed `src/login/login.ts` type-checks in isolation.

Companion PRs:
- QonicInfrastructure: https://qonic.ghe.com/iQonic/QonicInfrastructure/pull/268
- Qonic: https://qonic.ghe.com/iQonic/Qonic/pull/20768
- ApiPythonSample: https://github.com/QonicOpen/ApiPythonSample/pull/31

GrasshopperGltf lives in the Qonic repo and is covered by the Qonic PR.